### PR TITLE
Vagrant user uid gid docker

### DIFF
--- a/Vagrantfile.docker
+++ b/Vagrantfile.docker
@@ -2,6 +2,13 @@ ENV['VAGRANT_NO_PARALLEL'] = 'yes'
 
 net_name = "codeenigma-cevm"
 
+# Vagrant uid change.
+$vagrant_uid = <<SCRIPT
+usermod -u #{parsed_conf['docker_vagrant_user_uid']} vagrant
+groupmod -g #{parsed_conf['docker_vagrant_group_gid']} vagrant
+chown -R vagrant:www-data /vagrant
+SCRIPT
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   ################# Common config.
@@ -23,14 +30,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     shared_volumes.each do |synced_folder|
       db.vm.synced_folder synced_folder['source'], synced_folder['dest']
     end
+    # First ensure 'vagrant' ownership match.
+    db.vm.provision "shell", inline: $vagrant_uid
     # Provisioning. First install ansible from repo.
     db.vm.provision "shell", inline: $ansible
     # Run actual playbooks.
     run_playbook_dirs.each do |ansible_folder|
-        db.vm.provision 'ansible_local', run: "always" do |ansible|
-          ansible.playbook = "#{ansible_folder}/db.yml"
-          ansible.extra_vars = ansible_extra_vars
-        end
+      db.vm.provision 'ansible_local', run: "always" do |ansible|
+        ansible.playbook = "#{ansible_folder}/db.yml"
+        ansible.extra_vars = ansible_extra_vars
+      end
     end
     # Docker settings.
     db.vm.provider "docker" do |d|
@@ -58,6 +67,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     shared_volumes.each do |synced_folder|
       app.vm.synced_folder synced_folder['source'], synced_folder['dest']
     end
+    # First ensure 'vagrant' ownership match.
+    app.vm.provision "shell", inline: $vagrant_uid
     # Provisioning. First install ansible from repo.
     app.vm.provision "shell", inline: $ansible
     # Run actual playbooks.

--- a/Vagrantfile.docker
+++ b/Vagrantfile.docker
@@ -4,9 +4,25 @@ net_name = "codeenigma-cevm"
 
 # Vagrant uid change.
 $vagrant_uid = <<SCRIPT
-usermod -u #{parsed_conf['docker_vagrant_user_uid']} vagrant
-groupmod -g #{parsed_conf['docker_vagrant_group_gid']} vagrant
-chown -R vagrant:www-data /vagrant
+OWN_CHANGED=0
+if [ "$(id -u vagrant)" != "#{parsed_conf['docker_vagrant_user_uid']}" ]; then
+  usermod -u #{parsed_conf['docker_vagrant_user_uid']} vagrant
+  echo "User ID changed to #{parsed_conf['docker_vagrant_user_uid']}."
+  chown -R vagrant:www-data /vagrant
+  echo "Changed ownership of shared files accordingly."
+  OWN_CHANGED=1
+fi
+if [ "$(id -g vagrant)" != "#{parsed_conf['docker_vagrant_group_gid']}" ]; then
+  groupmod -g #{parsed_conf['docker_vagrant_group_gid']} vagrant
+  OWN_CHANGED=1
+fi
+if [ $OWN_CHANGED -eq 1 ]; then
+  echo "Interrupting the provisioning for the ownership changes to take effect."
+  echo "This will trigger a Vagrant error below, do not panic this is normal."
+  echo "Please manually relaunch the process using 'vagrant up'."
+  exit 1
+fi
+
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/config.yml
+++ b/config.yml
@@ -154,3 +154,11 @@ docker_db_fwd_ports:
  - "22203:22"
  - "3306:3306"
  - "11211:11211"
+
+# Vagrant user uid and group gid. 
+# You normally don't have to change this,
+# the only exception being Docker on a 
+# Linux host, where it should match your 
+# actual user uid/gid.
+docker_vagrant_user_uid: 1000
+docker_vagrant_group_gid: 1000


### PR DESCRIPTION
Closes #23. It is not perfect in that we need to interrupt the initial provisioning if there is an uid change, but could not find a workaround, so better than nothing for now.