### PR TITLE
Changes shared cache management and CE home mount mechanism

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -144,7 +144,8 @@ shared_volumes = []
 shared_volumes.push({'source' => "#{host_project_dir}", 'dest' => "#{guest_project_dir}"})
 host_ce_home = File.join("#{host_home_dir}", "#{ce_vm_local_home}")
 guest_ce_home = File.join("#{guest_home_dir}", "#{ce_vm_local_home}")
-shared_volumes.push({'source' => "#{host_ce_home}", 'dest' => "#{guest_ce_home}"})
+# "Internal" shared volume, we'll mount it separately.
+home_ce_volume = {'source' => "#{host_ce_home}", 'dest' => "#{guest_ce_home}"}
 
 # Gather playbooks.
 run_playbook_dirs = playbooks_find(host_playbook_dirs, guest_playbook_dirs)

--- a/Vagrantfile.docker
+++ b/Vagrantfile.docker
@@ -2,6 +2,9 @@ ENV['VAGRANT_NO_PARALLEL'] = 'yes'
 
 net_name = "codeenigma-cevm"
 
+# Shared folders have no options.
+shared_volumes.push(home_ce_volume)
+
 # Vagrant uid change.
 $vagrant_uid = <<SCRIPT
 OWN_CHANGED=0

--- a/Vagrantfile.virtualbox
+++ b/Vagrantfile.virtualbox
@@ -4,6 +4,7 @@
 
 # Default native options. 
 folder_sync_options = {type: "virtualbox", owner: "vagrant", group: "www-data", :mount_options => ['dmode=775,fmode=774']}
+folder_sync_home_ce_options = {type: "virtualbox", owner: "vagrant", group: "root", :mount_options => ['dmode=775,fmode=774']}
 # Rsync support.
 if(parsed_conf['vbox_synced_folder_type'] == "rsync")
   rsync_exclude_paths = [
@@ -48,6 +49,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     shared_volumes.each do |synced_folder|
       db.vm.synced_folder synced_folder['source'], synced_folder['dest'], folder_sync_options
     end
+    db.vm.synced_folder home_ce_volume['source'], home_ce_volume['dest'], folder_sync_home_ce_options
     # Provisioning. First install ansible from repo.
     db.vm.provision "shell", inline: $ansible
     # Run actual playbooks.
@@ -78,6 +80,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     shared_volumes.each do |synced_folder|
       app.vm.synced_folder synced_folder['source'], synced_folder['dest'], folder_sync_options
     end
+    app.vm.synced_folder home_ce_volume['source'], home_ce_volume['dest'], folder_sync_home_ce_options
     # Provisioning. First install ansible from repo.
     app.vm.provision "shell", inline: $ansible
     # Run actual playbooks.

--- a/ansible/roles/ce.composer/tasks/main.yml
+++ b/ansible/roles/ce.composer/tasks/main.yml
@@ -40,13 +40,15 @@
 
 - name: Create composer shared cache dir if needed.
   file:
-    path: '{{ ce_vm_home }}/cache/composer'
+    path: '{{ shared_cache_dir }}/composer'
+    owner: 'vagrant'
+    group: 'root'
     state: directory
     
 - name: Symlink composer shared cache.
   file:
     path: '/home/vagrant/.composer/cache'
-    src: '{{ ce_vm_home }}/cache/composer'
+    src: '{{ shared_cache_dir }}/composer'
     owner: 'vagrant'
-    group: 'vagrant'
+    group: 'root'
     state: link

--- a/ansible/roles/ce.nodejs/tasks/main.yml
+++ b/ansible/roles/ce.nodejs/tasks/main.yml
@@ -29,7 +29,9 @@
     
 - name: Create NodeJS shared cache dir if needed.
   file:
-    path: '{{ ce_vm_home }}/cache/nodejs'
+    path: '{{ shared_cache_dir }}/nodejs'
+    owner: 'vagrant'
+    group: 'root'
     state: directory
     
 - name: Set cache location.

--- a/ansible/roles/ce.nodejs/templates/npmrc.j2
+++ b/ansible/roles/ce.nodejs/templates/npmrc.j2
@@ -1,1 +1,1 @@
-cache="{{ ce_vm_home }}/cache/nodejs"
+cache="{{ shared_cache_dir }}/nodejs"

--- a/ansible/tasks/init-debian.yml
+++ b/ansible/tasks/init-debian.yml
@@ -1,10 +1,10 @@
 ---
 
+- set_fact: shared_cache_dir="{{ ce_vm_home }}/cache/{{ vagrant_provider }}"
+
 - name: Create apt cache dir if needed.
   file:
-    path: '{{ ce_vm_home }}/cache/apt'
-    owner: 'root'
-    group: 'root'
+    path: '{{ shared_cache_dir }}/apt'
     state: directory
 
 - name: Move apt cache to shared dir.

--- a/ansible/tasks/templates/apt-cache.j2
+++ b/ansible/tasks/templates/apt-cache.j2
@@ -1,2 +1,2 @@
-Dir{Cache /home/vagrant/.CodeEnigma/ce-vm/cache/apt}
-Dir::Cache /home/vagrant/.CodeEnigma/ce-vm/cache/apt;
+Dir::Cache{Archives {{ shared_cache_dir }}/apt}
+Dir::Cache::Archives {{ shared_cache_dir }}/apt;


### PR DESCRIPTION
This changes the "ce" home folder mounting to always use vboxfs. While it should make the provisioning marginally slower, the difference is to tiny compared to the benefit of having only one use case to take into account that it looks worth it. It also prevents issues with file ownership when switching the mount types between several instance.
Incidentally it should solve https://github.com/hashicorp/vagrant/issues/6513 (not by actually fixing it, just by chance in that it means only one mount point per VM uses NFS at a a time).
It also separate docker "shared cache" from virtualbox one, again to avoid ownership issues when switching providers.
Lastly, it brings a tiny change in apt cache handling by only using the shared cache for packages, and not for pkgcache.bin, srcpkgcache.bin anymore, as this did ot bring any speed improvement.