### PR TITLE
#45: Fixed plugins auto-install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,17 +118,17 @@ def ensure_docker_id(service, name)
   File.write(docker_id_file, docker_id)
 end
 
-# Ensure plugins are installed (taken from https://github.com/roots/trellis/pull/829/commits/b0563ed0492757db4a972b22d20e09f2f7ac2ac4).
+# Ensure plugins are installed (updated Aug 31, 2018: https://stackoverflow.com/questions/19492738/demand-a-vagrant-plugin-within-the-vagrantfile/28801317#28801317).
 def ensure_plugins(plugins)
   logger = Vagrant::UI::Colored.new
-  plugins.each do |plugin|
-    manager = Vagrant::Plugin::Manager.instance
-    next if manager.installed_plugins.has_key?(plugin)
-    logger.warn("Installing missing dependancy plugin #{plugin}.")
-    manager.install_plugin(plugin)
-    # Exit after installation, to avoid https://github.com/hashicorp/vagrant/issues/2435.
-    logger.warn("Please re-run the initial command.")
-    exit
+  plugins_to_install = plugins.select { |plugin| not Vagrant.has_plugin? plugin }
+  if not plugins_to_install.empty?
+    puts "Installing plugins: #{plugins_to_install.join(' ')}"
+    if system "vagrant plugin install #{plugins_to_install.join(' ')}"
+      exec "vagrant #{ARGV.join(' ')}"
+    else
+      abort "Installation of one or more plugins has failed. Aborting."
+    end
   end
 end
 
@@ -264,7 +264,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   ################# Common config.
   config.ssh.insert_key = false
   config.ssh.forward_agent = true
-  ################# END Common config.  
+  ################# END Common config.
 
   # Iterate over services.
   services.each do |service|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -123,12 +123,14 @@ def ensure_plugins(plugins)
   logger = Vagrant::UI::Colored.new
   plugins_to_install = plugins.select { |plugin| not Vagrant.has_plugin? plugin }
   if not plugins_to_install.empty?
-    puts "Installing plugins: #{plugins_to_install.join(' ')}"
+    logger.warn("Installing plugins: #{plugins_to_install.join(' ')}")
     if system "vagrant plugin install #{plugins_to_install.join(' ')}"
-      exec "vagrant #{ARGV.join(' ')}"
+      # Exit after installation, to avoid https://github.com/hashicorp/vagrant/issues/2435.
+      logger.warn("Plugins installed. Please re-run the initial command.")
     else
-      abort "Installation of one or more plugins has failed. Aborting."
+      logger.error("Installation of one or more plugins has failed. sudo must be used to install plugins. Aborting.")
     end
+    exit
   end
 end
 


### PR DESCRIPTION
This pull request fix the problem auto-installing plugins.
Due to it must be executed in the inital setup, I could not use a trigger as I wanted, otherwise the process gives an error here:

container.hostsupdater.aliases = service_conf['host_aliases']