### PR TITLE
#40: Applying triggers instead of some exec commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
  - PROJECT=custom FS=native
 
 install:
- - curl -O https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.deb
- - sudo dpkg -i vagrant_2.0.3_x86_64.deb
+ - curl -O https://releases.hashicorp.com/vagrant/2.1.5/vagrant_2.1.5_x86_64.deb
+ - sudo dpkg -i vagrant_2.1.5_x86_64.deb
  - vagrant plugin install vagrant-hostsupdater
 
 script:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,8 +13,11 @@ ENV['VAGRANT_DEFAULT_PROVIDER'] = 'docker'
 ENV['VAGRANT_NO_PARALLEL'] = 'yes'
 # Ensure this is not nil.
 ENV['VAGRANT_DOTFILE_PATH'] = '.vagrant' if ENV['VAGRANT_DOTFILE_PATH'].nil?
+# Define a global logger.
+$logger = Vagrant::UI::Colored.new
 
 require 'yaml'
+require 'find'
 
 ################ Helper functions.
 ################################################################################
@@ -115,19 +118,45 @@ end
 
 # Ensure plugins are installed (updated Aug 31, 2018: https://stackoverflow.com/questions/19492738/demand-a-vagrant-plugin-within-the-vagrantfile/28801317#28801317).
 def ensure_plugins(plugins)
-  logger = Vagrant::UI::Colored.new
   plugins_to_install = plugins.select { |plugin| not Vagrant.has_plugin? plugin }
   if not plugins_to_install.empty?
-    logger.warn("Installing plugins: #{plugins_to_install.join(' ')}")
+    $logger.warn("Installing plugins: #{plugins_to_install.join(' ')}")
     if system "vagrant plugin install #{plugins_to_install.join(' ')}"
       # Exit after installation, to avoid https://github.com/hashicorp/vagrant/issues/2435.
-      logger.warn("Plugins installed. Please re-run the initial command.")
+      $logger.warn("Plugins installed. Please re-run the initial command.")
     else
-      logger.error("Installation of one or more plugins has failed. sudo must be used to install plugins. Aborting.")
+      $logger.error("Installation of one or more plugins has failed. sudo must be used to install plugins. Aborting.")
     end
     exit
   end
 end
+
+# Override configuration using "overrides" folder
+# https://www.vagrantup.com/docs/provisioning/file.html
+def apply_overrides(container, service)
+  host_overrides_service_dir = File.join($host_overrides_dir, service)
+  if not File.directory?(host_overrides_service_dir)
+    # Nothing to do
+    return
+  end
+  # Copy into /tmp folder first using the provisioner.
+  files = []
+  Find.find(host_overrides_service_dir) do |path|
+    if File.file?(path)
+      # remove the initial path to know where to move it properly inside the guest machine
+      relative_path = path.gsub("./overrides/#{service}/", "")
+      files.push(relative_path)
+      container.vm.provision "file", source:"#{path}", destination:"/tmp/overrides/#{relative_path}"
+    end
+  end
+  
+  # Move to the right folder using the shell provisioner
+  files.each do |file|
+    # We assume that the directory exists
+    container.vm.provision "shell", inline:"sudo mv -f /tmp/overrides/#{file} /#{file}"
+  end
+end
+################ END Helper functions.
 
 ################ Paths definitions.
 ################################################################################
@@ -147,6 +176,8 @@ ce_vm_upstream_branch = ENV['CE_VM_UPSTREAM_BRANCH']
 # Absolute paths on the host machine.
 host_project_dir = File.dirname(File.expand_path('..', ENV['PROJECT_VAGRANTFILE']))
 host_home_dir = File.expand_path('~')
+$host_overrides_dir = File.join(".", "overrides")
+
 # Absolute paths on the guest machine.
 guest_project_dir = '/vagrant'
 guest_home_dir = '/home/vagrant'
@@ -295,26 +326,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
     end
 
-    ####### General triggers.
-    # We can not run more than one command under the same event.
-    # So we need to define the same event twice here (two .before : up)
-    #######
-
-    if(host_platform == "mac_os")
-      config.trigger.before :up do |trigger|
-        trigger.name = "ensure_lo_alias"
-        trigger.run = {inline: "sudo ifconfig lo0 alias #{ip}/32"}
-        trigger.warn = "Ensure loopback interface alias exists for #{ip}"
-      end
-    end
-
-    config.trigger.before :up do |trigger|
-      trigger.name = "ensure_docker_id"
-      ensure_docker_id(service, name)
-    end
-
-    ####### END General triggers
-
     # @TODO this could be an option.
     is_primary = false
     if (service === 'cli')
@@ -375,8 +386,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           #ansible.compatibility_mode = '2.0'
         end
       end
+      
       # Run startup scripts, post provisioning.
       container.vm.provision "shell", run: "always", inline: "sudo run-parts /opt/run-parts"
+      
       # Docker settings.
       container.vm.provider "docker" do |d|
         docker_args = [
@@ -408,6 +421,32 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         d.create_args = docker_args
         d.cmd = ["/bin/sh", "/opt/ce-vm-start.sh", "#{service_conf['docker_vagrant_user_uid']}", "#{service_conf['docker_vagrant_group_gid']}"]
       end
+      
+      ####### Triggers.
+      # We can not run more than one command under the same event.
+      # So we need to define the same event twice here (two .before : up)
+      #######
+
+      if(host_platform == "mac_os")
+        container.trigger.before :up do |trigger|
+          trigger.name = "ensure_lo_alias"
+          trigger.run = {inline: "sudo ifconfig lo0 alias #{ip}/32"}
+          trigger.warn = "Ensure loopback interface alias exists for #{ip}"
+        end
+      end
+
+      container.trigger.before :up do |trigger|
+        trigger.name = "ensure_docker_id"
+        ensure_docker_id(service, name)
+      end
+
+      container.trigger.after :provision do |trigger|
+        trigger.name = "apply_overrides"
+        trigger.warn = 'Overriding files inside "overrides/#{service}" folder...'
+        apply_overrides(container, service)
+      end
+
+      ####### END General triggers
     end
   end
   ################# END Individual container.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -205,7 +205,7 @@ end
 _ce_upstream = File.join("#{host_home_dir}", "#{ce_vm_local_upstream_repo}")
 if (ARGV.include? 'up') || (ARGV.include? 'halt')
   if(parsed_conf['ce_vm_auto_update'] === true)
-    # We cannot run this using triggers, but this is run at the beginnig.
+    # We cannot run this using triggers, it is run at the beginnig.
     puts "Ensure ce-vm is up-to-date."
     Vagrant::Util::Subprocess.execute("git", "-C", "#{_ce_upstream}", "fetch")
     Vagrant::Util::Subprocess.execute("git", "-C", "#{_ce_upstream}", "checkout", "#{ce_vm_upstream_branch}")

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -430,8 +430,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if(host_platform == "mac_os")
         container.trigger.before :up do |trigger|
           trigger.name = "ensure_lo_alias"
-          trigger.run = {inline: "sudo ifconfig lo0 alias #{ip}/32"}
-          trigger.warn = "Ensure loopback interface alias exists for #{ip}"
+          trigger.run = {inline: "sudo ifconfig lo0 alias #{net_ip}/32"}
+          trigger.warn = "Ensure loopback interface alias exists for #{net_ip}"
         end
       end
 


### PR DESCRIPTION
I have moved/removed some "exec" commands to use triggers instead.
I could not update all the exec commands, some of them are executed inside the init tasks, and there isn't a trigger to handle initial tasks.

The implemented triggers involve all the services, so I have put them in the Vagrantfile.

Looks like core triggers are a bit limited, eg, we can only "fire" a trigger.run command for each event.

Let see in future versions.