### PR TITLE
Adds simplesamlphp role

### DIFF
--- a/ansible/cli.yml
+++ b/ansible/cli.yml
@@ -21,6 +21,7 @@
     - { role: symfony4, when: project_type == 'symfony4' }
     - { role: wordpress, when: project_type == 'wordpress' }
     - { role: custom, when: project_type == 'custom' }
+    - { role: simplesamlphp, when: simplesamlphp }
 
   post_tasks:
     

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -3,3 +3,4 @@
 # Settings for nginx.
 ssl_handling: 'self'
 ssl_letsencrypt_mail: '{{ project_name }}@{{ domain }}'
+simplesamlphp_config: 'simplesamlphp/local'

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -18,6 +18,16 @@
     mode: 0644
     force: yes
 
+- name: Copy SimpleSamlPHP configuration in place.  
+  template:
+    src: "simplesamlphp.j2"
+    dest: "/etc/nginx/conf.d/simplesamlphp"
+    owner: root
+    group: root
+    mode: 0644
+    force: yes
+  when: simplesamlphp
+
 - name: Ensure default nginx catch-all is not present
   file:
     path: "/etc/nginx/sites-enabled/default"
@@ -71,3 +81,18 @@
   when: 
     - ssl_handling == "letsencrypt"
     - not letsencrypt_cert.stat.exists
+
+- name: Check if we have a certificate for SimpleSAMLPHP.
+  stat:
+    path: '/etc/letsencrypt/live/simplesamlphp.{{ service_hostname }}/fullchain.pem'
+  register: letsencrypt_simplesaml_cert
+  when: 
+    - ssl_handling == "letsencrypt"
+    - simplesamlphp
+
+- name: Register certificate if needed.
+  command: "/usr/bin/certbot certonly -n --cert-name simplesaml.{{ service_hostname }} --standalone --preferred-challenges http -d simplesamlphp.{{ service_hostname }} --agree-tos -m {{ ssl_letsencrypt_mail }}"
+  when: 
+    - ssl_handling == "letsencrypt"
+    - simplesamlphp
+    - not letsencrypt_simplesaml_cert.stat.exists

--- a/ansible/roles/nginx/templates/section.html.j2
+++ b/ansible/roles/nginx/templates/section.html.j2
@@ -6,4 +6,10 @@
     <p>HTTPS: <a href="https://{{ service_hostname }}">https://{{ service_hostname }}</a></p>
     <em>HTTPS uses a self-signed certificate, you will need to add an exception.</em>
   </div>
+{% if simplesamlphp %}
+  <div class="content">
+    <p>HTTP: <a href="http://simplesamlphp.{{ service_hostname }}">http://simplesamlphp.{{ service_hostname }}</a></p>
+    <p>HTTPS: <a href="https://simplesamlphp.{{ service_hostname }}">https://simplesamlphp.{{ service_hostname }}</a></p>
+  </div>
+{% endif %}
 </section>

--- a/ansible/roles/nginx/templates/simplesamlphp.j2
+++ b/ansible/roles/nginx/templates/simplesamlphp.j2
@@ -1,0 +1,38 @@
+location / {
+  try_files $uri /index.php$is_args$args;
+}
+
+location ~ \.php(/|$) {
+  include fastcgi_params;
+  fastcgi_split_path_info ^(.+\.php)(/.*)$;
+  fastcgi_param PATH_INFO $fastcgi_path_info;
+  fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+  fastcgi_param DOCUMENT_ROOT $realpath_root;
+  fastcgi_param SIMPLESAMLPHP_CONFIG_DIR "{{ project_dir }}/{{ simplesamlphp_config }}/config";
+  fastcgi_pass {{ project_name }}-fpm:9000;
+}
+
+gzip on;
+gzip_proxied any;
+gzip_static on;
+gzip_http_version 1.0;
+gzip_disable "MSIE [1-6]\.";
+gzip_vary on;
+gzip_comp_level 6;
+gzip_types
+    text/plain
+    text/css
+    text/xml
+    text/javascript
+    application/javascript
+    application/x-javascript
+    application/json
+    application/xml
+    application/xml+rss
+    application/xhtml+xml
+    application/x-font-ttf
+    application/x-font-opentype
+    image/svg+xml
+    image/x-icon;
+gzip_buffers 16 8k;
+gzip_min_length 512;

--- a/ansible/roles/nginx/templates/vhosts.j2
+++ b/ansible/roles/nginx/templates/vhosts.j2
@@ -39,3 +39,31 @@ server {
         fastcgi_pass {{ project_name }}-fpm:9000;
     }
 }
+
+{% if simplesamlphp %}
+
+server {
+    listen 443 ssl;
+    server_name "simplesamlphp.{{ service_hostname }}";
+    {% if ssl_handling == "letsencrypt" %}
+    ssl_certificate /etc/letsencrypt/live/simplesamlphp.{{ service_hostname }}/cert.pem;
+    ssl_certificate_key /etc/letsencrypt/live/simplesamlphp.{{ service_hostname }}/privkey.pem;
+    {% else %}
+    ssl_certificate /etc/nginx/ssl/ce-vm-self.crt;
+    ssl_certificate_key /etc/nginx/ssl/ce-vm-self.key;
+    {% endif %}
+    error_log syslog:server={{ project_name }}-log:{{ rsyslog_listen_port }} info;
+    access_log syslog:server={{ project_name }}-log:{{ rsyslog_listen_port }};
+    root "{{ project_dir }}/vendor/simplesamlphp/simplesamlphp/www";
+    include "/etc/nginx/conf.d/simplesamlphp";
+}
+
+server {
+    listen 80;
+    server_name "simplesamlphp.{{ service_hostname }}";
+    error_log syslog:server={{ project_name }}-log:{{ rsyslog_listen_port }} info;
+    access_log syslog:server={{ project_name }}-log:{{ rsyslog_listen_port }};
+    root "{{ project_dir }}/vendor/simplesamlphp/simplesamlphp/www";
+    include "/etc/nginx/conf.d/simplesamlphp";
+}
+{% endif %}

--- a/ansible/roles/simplesamlphp/defaults/main.yml
+++ b/ansible/roles/simplesamlphp/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Path to the SimpleSAMLPHP config, relative to project's root.
+simplesamlphp_config: 'simplesamlphp/local'

--- a/ansible/roles/simplesamlphp/tasks/main.yml
+++ b/ansible/roles/simplesamlphp/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+
+- name: Check if we already have a composer file.
+  stat: path="{{ project_dir }}/composer.json"
+  register: simplesaml_composer
+
+- name: Generates composer.json file if none exist.
+  template:
+    src: composer.json.j2
+    dest: "{{ project_dir }}/composer.json"
+    owner: vagrant
+    group: vagrant
+  when: 
+    - not simplesaml_composer.stat.exists
+    
+- name: Require SimpleSaml.
+  composer:
+    command: require
+    arguments: "simplesamlphp/simplesamlphp --sort-packages"
+    working_dir: "{{ project_dir }}"
+
+- name: Fix vendor dir permissions.
+  file: 
+    path: "{{ project_dir }}/vendor"
+    state: directory
+    owner: vagrant
+    group: vagrant
+    recurse: yes
+    
+- name: Check if we already have a simplesamlphp config folder.
+  stat: path="{{ project_dir }}/{{ simplesamlphp_config }}"
+  register: simplesaml_config_dir
+
+- name: Creates directory
+  file: 
+    path: "{{ project_dir }}/{{ simplesamlphp_config }}"
+    state: directory
+    recurse: yes
+    owner: vagrant
+    group: vagrant
+
+- name: Generate default SimpleSaml config.
+  synchronize:
+    src: "{{ project_dir }}/vendor/simplesamlphp/simplesamlphp/config-templates/"
+    dest: "{{ project_dir }}/{{ simplesamlphp_config }}/config"
+  become: yes
+  become_user: vagrant
+  when: 
+    - not simplesaml_config_dir.stat.exists
+
+- name: Generate default SimpleSaml metadata.
+  synchronize:
+    src: "{{ project_dir }}/vendor/simplesamlphp/simplesamlphp/metadata-templates/"
+    dest: "{{ project_dir }}/{{ simplesamlphp_config }}/metadata"
+  become: yes
+  become_user: vagrant
+  when: 
+    - not simplesaml_config_dir.stat.exists
+
+- name: Change default SimpleSaml base url.
+  replace:
+    path: "{{ project_dir }}/{{ simplesamlphp_config }}/config/config.php"
+    regexp: "'baseurlpath' => 'simplesaml/',"
+    replace: "'baseurlpath' => '',"

--- a/ansible/roles/simplesamlphp/templates/composer.json.j2
+++ b/ansible/roles/simplesamlphp/templates/composer.json.j2
@@ -1,0 +1,6 @@
+{
+    "name": "example/simplesamlphp",
+    "description": "StarterKit for SimpleSamlPHP",
+    "type": "project",
+    "require": {}
+}

--- a/config.yml
+++ b/config.yml
@@ -55,6 +55,8 @@ domain: 'ce-vm.local'
 # Apply the same php version to both cli and fpm.
 php_version: 7.1
 
+simplesamlphp: no
+
 # Extra Debian packages to install.
 apt_extra_packages: ''
 

--- a/service.nginx.yml
+++ b/service.nginx.yml
@@ -2,6 +2,7 @@
 
 host_aliases:
   - php.{{ project_name }}-nginx.{{ domain }}
+  - simplesamlphp.{{ project_name }}-nginx.{{ domain }}
 
 docker_image: "pmce/ce-vm-nginx:{{ ce_vm_version }}"
 net_ip: "{{ net_base }}.90"


### PR DESCRIPTION
Adds a simplesaml role that can generate a boilerplate structure and additional nginx config. It gets installed in the same instance than the main "project".
A standalone simplesamlphp project can be created by curating the vhost config manually and using the "custom" project type.