### PR TITLE
Bump the version

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -65,7 +65,7 @@ apt_extra_packages: ''
 # individually in ~/.CodeEnigma/ce-vm/ce-vm-custom/config.yml instead.
 ################################################################################
 
-ce_vm_version: "7.0.3"
+ce_vm_version: "7.0.4"
 
 # Turn automatic update of the core stack ON/OFF.
 # Useful for offline use.


### PR DESCRIPTION
Corresponds to ce-vm-base pull request to change drush installation to
use a symlink rather than renaming drush.phar to drush.